### PR TITLE
Remove env config from cron jobs

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -42,8 +42,8 @@ If the system is configured to queue emails, a cron job is required to process t
 
 ```
 php /path/to/mautic/app/console mautic:email:process
+```
 
 ## Note ##
 
 For releases prior to 1.1.3, it is required to append ` --env=prod` to the cron job command to ensure commands execute correctly.
-```

--- a/setup/README.md
+++ b/setup/README.md
@@ -8,7 +8,7 @@ Mautic requires a few cron jobs to handle some maintenance tasks.
 **To keep the smart lists current:**
 
 ```
-php /path/to/mautic/app/console mautic:leadlists:update --env=prod
+php /path/to/mautic/app/console mautic:leadlists:update
 ```
 
 By default, the script will process leads in batches of 300. If this is too many for your server's resources, use the option `--batch-limit=X` replacing X with the a number of leads to process each batch.
@@ -19,7 +19,7 @@ You can also limit the number of leads to process per script execution using `--
 **To keep campaigns updated with applicable leads:**
 
 ```
-php /path/to/mautic/app/console mautic:campaigns:update --env=prod
+php /path/to/mautic/app/console mautic:campaigns:update
 ```
 
 By default, the script will process leads in batches of 300. If this is too many for your server's resources, use the option `--batch-limit=X` replacing X with the a number of leads to process each batch.
@@ -29,7 +29,7 @@ You can also limit the number of leads to process per script execution using `--
 **To execute campaigns events:**
 
 ```
-php /path/to/mautic/app/console mautic:campaigns:trigger --env=prod
+php /path/to/mautic/app/console mautic:campaigns:trigger
 ```
 
 By default, the script will process events in batches of 100. If this is too many for your server's resources, use the option `--batch-limit=X` replacing X with the a number of events to process each batch.
@@ -41,5 +41,9 @@ You can also limit the number of leads to process per script execution using `--
 If the system is configured to queue emails, a cron job is required to process them.
 
 ```
-php /path/to/mautic/app/console mautic:email:process --env=prod
+php /path/to/mautic/app/console mautic:email:process
+
+## Note ##
+
+For releases prior to 1.1.3, it is required to append ` --env=prod` to the cron job command to ensure commands execute correctly.
 ```


### PR DESCRIPTION
As of 1.1.3 this is no longer required as the command line scripts default to the production environment.