### PR TITLE
Add missing closing tag for code block

### DIFF
--- a/en/contacts/contact_monitoring.md
+++ b/en/contacts/contact_monitoring.md
@@ -42,6 +42,7 @@ mt('send', 'pageview', {}, {
         redirect();
     }
 });
+```
 
 #### Local Contact Cookie
 


### PR DESCRIPTION
The closing tag for code block was missing, which broke the layout of the page.