### PR TITLE
Documentation for allowing a wild card character in CORS domains

### DIFF
--- a/en/contacts/contact_monitoring.md
+++ b/en/contacts/contact_monitoring.md
@@ -48,6 +48,8 @@ mt('send', 'pageview', {}, {
 
 As of Mautic 2.2.0, if CORS is configured to allow access from the domain the mtc.js is embedded, a cookie will be placed on the same domain with the name of `mtc_id`. This cookie will have the value of the ID for the currently tracked contact. This provides access to server side software to the contact ID and thus providing the ability to integrate with Mautic's REST API as well.
 
+Valid Domains for CORS are expected to include the full domain name as well as the protocol. (e.g. http://example.org). If you serve up secure and non-secure pages you should include both https://example.org as well http://example.org. All subdomains will need to be listed as well (e.g. http://example.org and and http://www.example.org ), if your server allows this. If you would like to allow all subdomains, an asterisk can be used as a wildcard (e.g. http://*.example.org).
+
 #### Tracking of custom parameters
 
 You can attach custom parameters or overwrite the automaticly generated parameters to the pageview action as you could to the tracking pixel query. To do that, update the last row of the JS code above like this:


### PR DESCRIPTION
Adding documentation for mautic/mautic#3398 which allows wildcards in the CORS domain.