### PR TITLE
Fix some broken links and add multilingual PDF download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This book serves as the [documentation for Mautic](https://mautic.org/docs/), th
 
 ### How to contribute to the docs
 
-This repository is the source code for [Gitbook](https://www.gitbook.com/) published at [www.mautic.org/docs](https://www.mautic.org/docs/index.html). The source code is shared [here on GitHub](https://github.com/mautic/documentation) so anyone could contribute to the documentation the same way the programmers do with the actual Mautic code. 
+This repository is the source code for [Gitbook](https://www.gitbook.com/) published at [www.mautic.org/docs](https://www.mautic.org/docs). The source code is shared [here on GitHub](https://github.com/mautic/documentation) so anyone could contribute to the documentation the same way the programmers do with the actual Mautic code. 
 
 #### Why is git used for the documentation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This book serves as the [documentation for Mautic](https://mautic.org/docs/), th
 ### Download as PDF!
 
 [Click here](https://mautic.org/docs/mautic_docs_en.pdf) to download these docs as a PDF in English.
+
 [Click here](https://mautic.org/docs/mautic_docs_fr.pdf) to download these docs as a PDF in French.
+
 [Click here](https://mautic.org/docs/mautic_docs_jp.pdf) to download these docs as a PDF in Japanese.
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Mautic Documentation
 
 ### Introduction
-This book serves as the [documentation for Mautic](https://www.mautic.org/docs/index.html), the open source marketing automation system. Just as the code is open source and available for everyone, so is the documentation. Everyone is welcome to help make this information better and improve as needed.
+This book serves as the [documentation for Mautic](https://mautic.org/docs/), the open source marketing automation system. Just as the code is open source and available for everyone, so is the documentation. Everyone is welcome to help make this information better and improve as needed.
 
 ### Download as PDF!
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ This book serves as the [documentation for Mautic](https://mautic.org/docs/), th
 
 ### Download as PDF!
 
-[Click here](https://mautic.org/docs/mautic_docs.pdf) to download these docs as a PDF.
+[Click here](https://mautic.org/docs/mautic_docs_en.pdf) to download these docs as a PDF in English.
+[Click here](https://mautic.org/docs/mautic_docs_fr.pdf) to download these docs as a PDF in French.
+[Click here](https://mautic.org/docs/mautic_docs_jp.pdf) to download these docs as a PDF in Japanese.
+
+
 
 ### How to contribute to the docs
 


### PR DESCRIPTION
I have fixed what I think is a broken link, which was pointing at the docs with /index.html.  This results in a pretty poor UI with huge flags and tiny text links.  

I think it would be better to drop them on the main docs page which has the option to easily change the language as required.

I've added the links to the multilingual PDF downloads, as the single link was broken.