### PR TITLE
Update outlook.md

### DIFF
--- a/en/plugins/outlook.md
+++ b/en/plugins/outlook.md
@@ -29,6 +29,9 @@ This plugin allows for the Outlook Add-In to keep track of emails sent to leads.
 
 7. This will append a tracking GIF to the email with the following syntax:  [[MAUTIC_URL]]/index.php/outlook/tracking.gif?d=H4sIAAAAAAAEAIVRTW%2FCMAz9LRyCtgNVlFBpHHroWsRuk8ak7RpaUzqaGCUp0H8%2Fpy0TH4dJUZy892w921uLOvkCa8BGK2WLWi2dt6pUbM7PYPEcFainoFXdJKdBVvUy4quA9rxrNz9Q%2BCQ16HdgmeAenKewpfIU3lvfIO6nGyy75HNXO8LQAN3984R2X5tqMpkwnjOejrfg19%2FBJIHBJsskS3M1MOvOedChUA5HaPBAsp54a7UyBH%2BAw9YWECRrsMc6PHvFd2iR0NfW1QbcjUDwMjhctYqqq0YxkQU6SqMhNxi85GeoD8p0134zaBom%2By4ezlPMxTPFeCH5TLzI%2BdgizeEu5aIUQixmIubjSG5WAY8bC8kyC%2FvxSBX%2Flcvl3bT%2Fvr8k1oBgIQIAAA%3D%3D&sig=cf078d5b
 
+>**Important**
+Appending a tracking pixel via the Outlook plugin means that there is a possibility for false positives on email opens. This edge case occurs if the user's Outlook has the Preview Pane enabled for Sent Messages.
+
 8. The Mautic plugin will then validate the information using the secret to compare signatures and then attach that email to the contact’s profile as part of their activity history. If the lead or leads don't exist, they are created automatically
 ![image](media/outlook/mautic_contacts.png)
 


### PR DESCRIPTION
Adds an aside to address a potential edge case where the preview pane is open and marks emails as read by the sender instead of the recipient.