### PR TITLE
Add a link to the apache foundation cron document

### DIFF
--- a/en/setup/cron_jobs.md
+++ b/en/setup/cron_jobs.md
@@ -2,6 +2,8 @@
 
 Mautic requires a few [cron jobs](https://en.wikipedia.org/wiki/Cron) to handle some maintenance tasks. Most web hosts provide a means to add cron jobs either through SSH, cPanel, or another custom panel. Please consult your host's documentation/support if you are unsure on how to setup cron jobs.
 
+If you're new to Linux or Cron Jobs, then the Apache Foundation have [an excellent guide](https://www.howtoforge.com/a-short-introduction-to-cron-jobs) which we would suggest that you read before asking questions via the various support channels.
+
 How frequently you run the cron jobs is up to you. Many shared hosts prefer that you run scripts every 15 or 30 minutes and may even override the scheduled times to meet these restrictions. Consult your host's documentation if they have such a restriction.
 
 **It is HIGHLY recommended that you stagger the following required jobs so as to not run the exact same minute.**


### PR DESCRIPTION
I've noticed that a number of queries in #support on Slack revolve around how to configure Cron.

This PR provides a link to a well written document by the Apache Foundation on how to configure crontabs