### PR TITLE
Add missing blank line before Markdown lists

### DIFF
--- a/en/emails/troubleshooting.md
+++ b/en/emails/troubleshooting.md
@@ -11,6 +11,7 @@ Some email clients have auto loading images disabled, and users have to click on
 Before an email is sent, Mautic replaces all links in the email with links back to Mautic including a unique key. If the contact clicks on such a link, the contact is redirected to Mautic. Mautic tracks the click action and redirects the contact to the original location. It's fast so the contact doesn't notice the additional redirect.
 
 If the email click doesn't get tracked, make sure that:
+
 1. Your Mautic server is on a public URL. Tracking doesn't work on a localhost.
 2. Make sure the email was sent to an existing contact via a campaign or a segment email. Emails sent by the *Send Example* link, *direct email* (from the contact detail) or *form submission preview* won't replace links with trackables.
 3. Make sure the URL in the `href` attribute is absolute and valid. It should start with http:// or https://.

--- a/en/pages/troubleshooting.md
+++ b/en/pages/troubleshooting.md
@@ -5,6 +5,7 @@
 Page hits are being tracked by a tracking pixel. That is simply a 1 pixel GIF image in the source code of the Page source code. When a page is hit by a browser, it tries to load the images in it. The image load request is actually what Mautic needs to track the page hit action.
 
 If the tracking doesn't work, check:
+
 1. The tracking doesn't work for logged in Mautic administrators. This way statistics aren't skewed by Mautic administrators looking at the page result while editing a page. So make sure you are logged out of Mautic or use an incognito browser window while testing the tracking.
 2. The tracking pixel isn't part of the page you want to track. Mautic can only track pages which have the tracking pixel in their source code.
 3. The tracking pixel is not configured correctly. You can confirm this by looking at the dev tools of your browser. While looking on the page you wish to track, open the dev tools (press F12), go to the Network tab and reload the page. You'll see all the requests which were made. Filter those requests to images only and find the mtracking.gif image. Does it have status 200? If not, the path to your Mautic instance is probably incorrect.


### PR DESCRIPTION
The troubleshooting checklists for emails and pages were not being rendered correctly:

- https://www.mautic.org/docs/en/emails/troubleshooting.html
- https://www.mautic.org/docs/en/pages/troubleshooting.html

I think this is because Markdown lists require a blank line before they start, but I can't be sure due to #311 and #312.