### PR TITLE
Placement of tracking pixel token in email

### DIFF
--- a/en/emails/README.md
+++ b/en/emails/README.md
@@ -51,7 +51,7 @@ You have access to any number of contact fields to be used in your form emails. 
 
 Each email sent through Mautic is tagged with a tracking pixel image. This allows Mautic to track when a contact opens the email and execute actions accordingly. Note that this technology is limited to the contact's email client supporting HTML and auto-loading of images. If the email client does not load the image, there is no way for Mautic to know if the email was opened.
 
-By default, the tracking pixel image is added at the end of the message, before the `</body>` tag. If needed, one could use the `{tracking_pixel}` with the body content token to have it placed elsewhere.
+By default, the tracking pixel image is added at the end of the message, just before the `</body>` tag. If needed, one could use the `{tracking_pixel}` within the body content token to have it placed elsewhere.
 
 ### Tracking trackable links in emails ###
 

--- a/en/emails/README.md
+++ b/en/emails/README.md
@@ -51,6 +51,7 @@ You have access to any number of contact fields to be used in your form emails. 
 
 Each email sent through Mautic is tagged with a tracking pixel image. This allows Mautic to track when a contact opens the email and execute actions accordingly. Note that this technology is limited to the contact's email client supporting HTML and auto-loading of images. If the email client does not load the image, there is no way for Mautic to know if the email was opened.
 
+By default, the tracking pixel image is added at the end of the message, before the `</body>` tag. If needed, one could use the `{tracking_pixel}` with the body content token to have it placed elsewhere.
 
 ### Tracking trackable links in emails ###
 

--- a/en/emails/manage_emails.md
+++ b/en/emails/manage_emails.md
@@ -32,11 +32,12 @@ The email builder provides quick and convenient access to assets, landing pages,
 
 Tokens can be used also for the Subject line, but there is no drop-down. You'll have to type it yourself or select it in the email body and copy-paste it to the subject field.
 
-Email Builder has also special tokens for the Unsubscribe link and the Webview link:
+Email Builder has also special tokens for the Unsubscribe link, Webview link and the Tracking pixel:
 - `{unsubscribe_text}` - Creates a link with the unsubscribed URL and the text defined in the Mautic configuration.
 - `{unsubscribe_url}` - Creates a URL to the unsubscribed page which can be used in a link's href attribute.
 - `{webview_text}` - Creates a link with the webview URL and the text defined in the Mautic configuration.
 - `{webview_url}` - Creates a URL to the webview page which can be used in a link's href attribute.
+- `{tracking_pixel}` - Creates a 1 pixel image that allows to track email open.
 
 
 #### Contact token modifiers
@@ -64,7 +65,7 @@ Your date will displayed as human reading format taken from  Configuration > Sys
 
 ### Tracking Pixel
 
-The tracking pixel image is appended to the email message, if enabled. If needed, one could insert the tracking pixel image with the special token `{tracking_pixel}` at any place other within the text body. Beware that it should not be inserted directly after the opening `<body>` because this prevents correct display of pre-header text on some MUAs
+The tracking pixel image is usually appended to the email message, if enabled. If needed, one could insert the tracking pixel image with the special token `{tracking_pixel}` at any place other within the text body. Beware that it should not be inserted directly after the opening `<body>` because this prevents correct display of pre-header text on some MUAs.
 
 ### Code Mode
 

--- a/en/emails/manage_emails.md
+++ b/en/emails/manage_emails.md
@@ -62,6 +62,10 @@ Your date will displayed as human reading format taken from  Configuration > Sys
 - Default format for date only  
 - Default Time Only Format 
 
+### Tracking Pixel
+
+The tracking pixel image is appended to the email message, if enabled. If needed, one could insert the tracking pixel image with the special token `{tracking_pixel}` at any place other within the text body. Beware that it should not be inserted directly after the opening `<body>` because this prevents correct display of pre-header text on some MUAs
+
 ### Code Mode
 
 [Go to the Code Mode docs](./../themes/code_mode.html).


### PR DESCRIPTION
Place the tracking pixel image freely within the message body as alternative to the default placement at the end of the <body>.