### PR TITLE
Use one campaign update command name in cron_jobs

### DIFF
--- a/en/setup/cron_jobs.md
+++ b/en/setup/cron_jobs.md
@@ -30,7 +30,7 @@ You can also limit the number of contacts to process per script execution using 
 **To keep campaigns updated with applicable contacts:**
 
 ```
-php /path/to/mautic/app/console mautic:campaigns:rebuild
+php /path/to/mautic/app/console mautic:campaigns:update
 ```
 
 By default, the script will process contacts in batches of 300. If this is too many for your server's resources, use the option `--batch-limit=X` replacing X with the a number of contacts to process each batch.

--- a/fr/setup/cron_jobs.md
+++ b/fr/setup/cron_jobs.md
@@ -8,7 +8,7 @@ How frequently you run the cron jobs is up to you. Many shared hosts prefer that
 
 For instance:
 - 0,15,30,45 <— segments:update
-- 5,20,35,50 <— camaigns:update
+- 5,20,35,50 <— campaigns:update
 - 10,25,40,55 <— campaigns:trigger
 
 ## Required ##
@@ -28,7 +28,7 @@ You can also limit the number of contacts to process per script execution using 
 **To keep campaigns updated with applicable contacts:**
 
 ```
-php /path/to/mautic/app/console mautic:campaigns:rebuild
+php /path/to/mautic/app/console mautic:campaigns:update
 ```
 
 By default, the script will process contacts in batches of 300. If this is too many for your server's resources, use the option `--batch-limit=X` replacing X with the a number of contacts to process each batch.

--- a/jp/setup/cron_jobs.md
+++ b/jp/setup/cron_jobs.md
@@ -23,7 +23,7 @@ php /path/to/mautic/app/console mautic:segments:update
 **適用するコンタクトとともにキャンペーンを最新の状態に保ちます:**
 
 ```
-php /path/to/mautic/app/console mautic:campaigns:rebuild
+php /path/to/mautic/app/console mautic:campaigns:update
 ```
 
 スクリプトがバッチ処理するコンタクトの数は300とデフォルトで設定されています。利用中のサーバリソースに対してこの数が多いようであれば `--batch-limit=X` オプションを使い，Xへ処理させるコンタクトの数に置き換えて調整してください。


### PR DESCRIPTION
Changed confusing campaign update command name usage in cron jobs docs. We should use one command name in example and campaign description. 

Linked topics:
[https://github.com/mautic/mautic/issues/5436](url)
[https://forum.mautic.org/t/cron-jobs-whats-the-difference/11177/2](url)