### PR TITLE
Remove undefined preference center variables

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -124,8 +124,6 @@ See [customizing preference center][make pref center] for more information.
 | Preferred Channel                                  | `{preferredchannel}`                        |
 | Channel Frequency                                  | `{channelfrequency}`                        |
 | Save Preferences                                   | `{saveprefsbutton}`                         |
-| Unsubscribe Text                                   | `{unsubscribe_text}`                        |
-| Unsubscribe URL                                    | `{unsubscribe_url}`                         |
 
 ## Dynamic Web Content tokens
 


### PR DESCRIPTION
This PR removes from documentation variables that do not exist in preferences center landing page.