### PR TITLE
Update bounce_management.md

### DIFF
--- a/en/emails/bounce_management.md
+++ b/en/emails/bounce_management.md
@@ -66,7 +66,8 @@ Mautic supports the bounce and complaint management from Amazon Simple Email Ser
 
 ![Topic](media/amazon_webhook_4.png "New subscriber")
 
-3) Enter the url to the Amazon webhook on your Mautic installation
+3) Enter the url to the Amazon webhook on your Mautic installation. 
+It should usually be your mautic URL followed by `/mailer/amazon/callback`
 
 ![Topic](media/amazon_webhook_5.png "Enter url to Mautic")
 


### PR DESCRIPTION
got SNS topic verification working as per the example
http://stage.domain.com/mautic/mailer/amazon/callback
so you have to suffix mailer/amazon/callback to your Mautic URL

it would really help if the docs mention it more clearly as in "TEXT" rather than just in the screenshot